### PR TITLE
Skills: remove Capabilities label, tighten chip spacing

### DIFF
--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -101,8 +101,10 @@ const groups = [
             {g.title}
           </h3>
           <p class="mt-3 flex-1 text-sm leading-relaxed text-slate-400 md:text-[15px]">{g.summary}</p>
-          <p class="skill-tags-label mt-7">Capabilities</p>
-          <ul class="project-tags mt-3 flex flex-wrap gap-2" aria-label={`${g.title} — capabilities`}>
+          <ul
+            class="project-tags mt-6 flex flex-wrap gap-x-2 gap-y-2.5 md:mt-7"
+            aria-label={`${g.title} — capability areas`}
+          >
             {g.tags.map((t) => (
               <li class="project-tag">{t}</li>
             ))}
@@ -149,14 +151,5 @@ const groups = [
     .skill-card:hover {
       transform: none;
     }
-  }
-
-  .skill-tags-label {
-    margin: 0;
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: rgba(148, 163, 184, 0.95);
   }
 </style>


### PR DESCRIPTION
- Drop redundant section label for a cleaner product UI
- Add margin and gap-y between chips after description